### PR TITLE
Bug: graceful handling of empty message table instead of exception

### DIFF
--- a/librus/__init__.py
+++ b/librus/__init__.py
@@ -193,20 +193,22 @@ class LibrusSession(object):
 
         for row in response.html.find('.stretch > tbody > tr'):
             cells = row.find('td')
-            href = cells[3].find('a')[0].attrs['href']
-            message = Message(
-                message_id=href.strip(),
-                sender=cells[2].text,
-                subject=cells[3].text,
-                sent_at=datetime.datetime.strptime(cells[4].text, '%Y-%m-%d %H:%M:%S'),
-                is_read=('font-weight: bold' not in cells[3].attrs.get('style', ''))
-            )
-            if get_content:
-                url = 'https://synergia.librus.pl' + href
-                content = self._html_session.get(url=url).html.find('.container-message-content')[0]
-                message.content = content.text
+            messages_available = len(cells) >= 4
+            if messages_available:
+                href = cells[3].find('a')[0].attrs['href']
+                message = Message(
+                    message_id=href.strip(),
+                    sender=cells[2].text,
+                    subject=cells[3].text,
+                    sent_at=datetime.datetime.strptime(cells[4].text, '%Y-%m-%d %H:%M:%S'),
+                    is_read=('font-weight: bold' not in cells[3].attrs.get('style', ''))
+                )
+                if get_content:
+                    url = 'https://synergia.librus.pl' + href
+                    content = self._html_session.get(url=url).html.find('.container-message-content')[0]
+                    message.content = content.text
 
-            yield message
+                yield message
 
     @staticmethod
     def _parse_absence(element):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name='librus',
     description="Librus Synergia API",
     url="https://github.com/findepi/librus-api-python",
-    version='0.0.14',
+    version='0.0.15',
     packages=find_packages(),
     setup_requires=[
         # 'pytest-runner==3.0',


### PR DESCRIPTION
I fixed a bug that occured when there were no messages (aka "wiadomości") available. Previously, it was raising an exception IndexError because of HTML table having less TDs in a row.